### PR TITLE
navegacion para ejemplos de uso

### DIFF
--- a/app/src/pages/ConfirmacionDeVenta/confirmacionVenta.js
+++ b/app/src/pages/ConfirmacionDeVenta/confirmacionVenta.js
@@ -4,12 +4,14 @@ import './confirmacionVenta.css'
 
 import { TarjetaProductoInformacionVenta, TarjetaNota, TarjetaDelivery } from './widgetsConfirmacionVenta';
 
+import { useNavigate } from 'react-router-dom';
 
 
 function ContenidoConfirmacionVenta (){
 
     const [tipoVenta, setTipoVenta] = useState('Delivery');
     
+    const navegar = useNavigate()
         
 
     return (
@@ -86,8 +88,8 @@ function ContenidoConfirmacionVenta (){
         <div className="frameBotones">
 
                         
-            <button id="btnCancelar" className="btnPedido">Cancelar</button>
-            <button id="btnContinuar" className="btnPedido">Completar venta</button>
+            <button id="btnCancelar" className="btnPedido" onClick={() => navegar("/Pedido")}>Regresar</button>
+            <button id="btnContinuar" className="btnPedido" onClick={() => navegar("/Inicio")}>Completar venta</button>
 
 
         </div>

--- a/app/src/pages/InformacionDeVenta/informacionDeVenta.js
+++ b/app/src/pages/InformacionDeVenta/informacionDeVenta.js
@@ -1,6 +1,7 @@
 import './informacionDeVenta.css'
 import Dashboard from "../reusables/dashboard-page";
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 
 
@@ -8,6 +9,8 @@ import React, { useState } from 'react';
 function ContenidoInformacionVenta(){
     
     const [Seleccion, setSeleccion] = useState("");
+
+    const navegar = useNavigate();
 
     return(
 
@@ -93,12 +96,14 @@ function ContenidoInformacionVenta(){
 
                 </div>
 
+                
+
             
                 <div className="frameBotones">
 
                 
                     <button id="btnCancelar" className="btnPedido">Cancelar</button>
-                    <button id="btnContinuar" className="btnPedido">Continuar</button>
+                    <button id="btnContinuar" className="btnPedido" onClick={() => navegar("/Pedido")}>Continuar</button>
 
 
                 </div>

--- a/app/src/pages/PatallaPedido/Pedido.js
+++ b/app/src/pages/PatallaPedido/Pedido.js
@@ -7,7 +7,11 @@ import { Pedido as WidgethPedido } from "./Widgets" ;
 import { WidgetNota } from "./Widgets";
 import Dashboard from "../reusables/dashboard-page";
 
+import { useNavigate } from "react-router-dom";
+
 function ContenidoPedido() {
+
+    const navegar = useNavigate()
 
     const [isVisible, setIsVisible] = useState(false);
 
@@ -134,8 +138,8 @@ function ContenidoPedido() {
             <div className="frameBotones">
 
                
-                <button id="btnCancelar" className="btnPedido">Cancelar</button>
-                <button id="btnContinuar" className="btnPedido">Continuar</button>
+                <button id="btnCancelar" className="btnPedido" onClick={() => navegar("/informacion_venta")}>Regresar</button>
+                <button id="btnContinuar" className="btnPedido" onClick={() => navegar("/Confirmacion_Venta")}>Continuar</button>
 
 
             </div>


### PR DESCRIPTION
Agregue de forma provisoria que se pueda navegar entre las pantallas de pedido usando los botones 